### PR TITLE
Feat 002 add username generator controller

### DIFF
--- a/src/controllers/UsernameGeneratorController.ts
+++ b/src/controllers/UsernameGeneratorController.ts
@@ -1,51 +1,109 @@
-import { FullNamesModel } from '@app/models';
+import { FullNamesModel, UsernameModel } from '@app/models';
 import { FilePathService, FullNamesService } from '@app/services';
 import { ICommonFuncMain } from '@app/interfaces/common';
-import { IModelFullNames, IModelFullNamesFuncNextOutput } from '@app/interfaces/models';
+import {
+	IControllerUsernameGenerator,
+	IControllerUsernameGeneratorConstructor,
+	IControllerUsernameGeneratorConstructorInput,
+	IControllerUsernameGeneratorFuncGenerate,
+	IControllerUsernameGeneratorFuncGenerateUsernameModels,
+	IControllerUsernameGeneratorFuncGenerateUsernameModelsInput,
+} from '@app/interfaces/controllers';
+import {
+	IModelFullName,
+	IModelFullNames,
+	IModelFullNamesFuncNextOutput,
+	IModelUsername,
+} from '@app/interfaces/models';
 import { IServiceFilePath, IServiceFullNames } from '@app/interfaces/services';
 
 /**
  * @public
  * @constructor
  *
- * @param filePathStr
- * @param delimiter
- * @param fullNameDelimiterEnum
+ * Construct an instance of the UsernameGeneratorController.
  *
+ * @param {IControllerUsernameGeneratorConstructorInput} args
+ * @param {ICommonPathStr} args.filePathStr
+ * @param {FileServiceDelimiterEnum} args.fileServiceDelimiterEnum
+ * @param { FullNameDelimiterEnum} args.fullNameDelimiterEnum
+ * @returns {IControllerUsernameGenerator}
  */
-export const UsernameGeneratorController = ({
+export const UsernameGeneratorController: IControllerUsernameGeneratorConstructor = ({
 	filePathStr,
-	delimiter,
-	fullNameDelimiterEnum
-}) => {
+	fileServiceDelimiterEnum,
+	fullNameDelimiterEnum,
+}: IControllerUsernameGeneratorConstructorInput): IControllerUsernameGenerator => {
 	let filePathService: IServiceFilePath;
 	let fullNamesService: IServiceFullNames;
 	let fullNamesModel: IModelFullNames;
 
 	/**
 	 * @public
+	 *
+	 * Entry point for the generation of username model,
+	 * using all fullName models.
+	 *
+	 * @returns {IModelUsername[]}
 	 */
-	const generate = (): number => {
+	const generate: IControllerUsernameGeneratorFuncGenerate = (): IModelUsername[] => {
+		let usernameModels: IModelUsername[] = [];
+
 		let fullNameModelWrapper: IModelFullNamesFuncNextOutput = fullNamesModel.next();
-		let count: number = 0;
+
 		while (!fullNameModelWrapper.done) {
-			//let fullNameModel: IModelFullName = fullNameModelWrapper.value;
-			// recursive call and merge
-			count++
+			const fullNameModel: IModelFullName = fullNameModelWrapper.value;
+			const generatedUsernameModels: IModelUsername[] = generateUsernameModels({ fullNameModel });
+			usernameModels = usernameModels.concat(generatedUsernameModels);
 			fullNameModelWrapper = fullNamesModel.next();
 		}
 
-		return count;
-	}
+		return usernameModels;
+	};
+
+	/**
+	 * @public
+	 *
+	 * Generate username models from a full name model in conjunction
+	 * with each of the relevant permutations.
+	 *
+	 * @param {IControllerUsernameGeneratorFuncGenerateUsernameModelsInput} args
+	 * @param {IModelFullName} args.fullNameModel
+	 * @returns {IModelUsername[]}
+	 */
+	const generateUsernameModels: IControllerUsernameGeneratorFuncGenerateUsernameModels = ({
+		fullNameModel,
+	}: IControllerUsernameGeneratorFuncGenerateUsernameModelsInput): IModelUsername[] => {
+		const usernameModel: IModelUsername = UsernameModel({ fullNameModel });
+
+		return [usernameModel];
+
+		/*
+		 * @TODO Once the permutations have been written,
+		 * add the required code below. Also, this function's
+		 * signature may require altering, in order to support
+		 * an array of permutations
+		 */
+
+		// iterate across the full name permutations
+		// generate a username name model from the first permutation
+		// add the generated model to the usernameModels array
+		// repeat
+	};
 
 	/**
 	 * @private
 	 */
 	const main: ICommonFuncMain = (): void => {
-		filePathService = FilePathService({ filePathStr, delimiter });
+		filePathService = FilePathService({ filePathStr, delimiter: fileServiceDelimiterEnum });
 		fullNamesService = FullNamesService({ filePathService });
 		fullNamesModel = FullNamesModel({ fullNamesService, fullNameDelimiterEnum });
-	}
+	};
 
 	main();
-}
+
+	return {
+		generate,
+		generateUsernameModels,
+	};
+};

--- a/src/controllers/UsernameGeneratorController.ts
+++ b/src/controllers/UsernameGeneratorController.ts
@@ -1,0 +1,51 @@
+import { FullNamesModel } from '@app/models';
+import { FilePathService, FullNamesService } from '@app/services';
+import { ICommonFuncMain } from '@app/interfaces/common';
+import { IModelFullNames, IModelFullNamesFuncNextOutput } from '@app/interfaces/models';
+import { IServiceFilePath, IServiceFullNames } from '@app/interfaces/services';
+
+/**
+ * @public
+ * @constructor
+ *
+ * @param filePathStr
+ * @param delimiter
+ * @param fullNameDelimiterEnum
+ *
+ */
+export const UsernameGeneratorController = ({
+	filePathStr,
+	delimiter,
+	fullNameDelimiterEnum
+}) => {
+	let filePathService: IServiceFilePath;
+	let fullNamesService: IServiceFullNames;
+	let fullNamesModel: IModelFullNames;
+
+	/**
+	 * @public
+	 */
+	const generate = (): number => {
+		let fullNameModelWrapper: IModelFullNamesFuncNextOutput = fullNamesModel.next();
+		let count: number = 0;
+		while (!fullNameModelWrapper.done) {
+			//let fullNameModel: IModelFullName = fullNameModelWrapper.value;
+			// recursive call and merge
+			count++
+			fullNameModelWrapper = fullNamesModel.next();
+		}
+
+		return count;
+	}
+
+	/**
+	 * @private
+	 */
+	const main: ICommonFuncMain = (): void => {
+		filePathService = FilePathService({ filePathStr, delimiter });
+		fullNamesService = FullNamesService({ filePathService });
+		fullNamesModel = FullNamesModel({ fullNamesService, fullNameDelimiterEnum });
+	}
+
+	main();
+}

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,0 +1,1 @@
+export { UsernameGeneratorController } from './UsernameGeneratorController';

--- a/src/interfaces/controllers/IControllerUsernameGenerator.ts
+++ b/src/interfaces/controllers/IControllerUsernameGenerator.ts
@@ -1,0 +1,7 @@
+import { IControllerUsernameGeneratorFuncGenerate } from './IControllerUsernameGeneratorFuncGenerate';
+import { IControllerUsernameGeneratorFuncGenerateUsernameModels } from './IControllerUsernameGeneratorFuncGenerateUsernameModels';
+
+export interface IControllerUsernameGenerator {
+	generate: IControllerUsernameGeneratorFuncGenerate;
+	generateUsernameModels: IControllerUsernameGeneratorFuncGenerateUsernameModels;
+}

--- a/src/interfaces/controllers/IControllerUsernameGeneratorConstructor.ts
+++ b/src/interfaces/controllers/IControllerUsernameGeneratorConstructor.ts
@@ -1,0 +1,6 @@
+import { IControllerUsernameGenerator } from './IControllerUsernameGenerator';
+import { IControllerUsernameGeneratorConstructorInput } from './IControllerUsernameGeneratorConstructorInput';
+
+export interface IControllerUsernameGeneratorConstructor {
+	(args: IControllerUsernameGeneratorConstructorInput): IControllerUsernameGenerator;
+}

--- a/src/interfaces/controllers/IControllerUsernameGeneratorConstructorInput.ts
+++ b/src/interfaces/controllers/IControllerUsernameGeneratorConstructorInput.ts
@@ -1,0 +1,8 @@
+import { FileServiceDelimiterEnum, FullNameDelimiterEnum } from '@app/config/enums';
+import { ICommonPathStr } from '@app/interfaces/common';
+
+export interface IControllerUsernameGeneratorConstructorInput {
+	filePathStr: ICommonPathStr;
+	fileServiceDelimiterEnum: FileServiceDelimiterEnum;
+	fullNameDelimiterEnum: FullNameDelimiterEnum;
+}

--- a/src/interfaces/controllers/IControllerUsernameGeneratorFuncGenerate.ts
+++ b/src/interfaces/controllers/IControllerUsernameGeneratorFuncGenerate.ts
@@ -1,0 +1,5 @@
+import { IControllerUsernameGeneratorFuncGenerateOutput } from './IControllerUsernameGeneratorFuncGenerateOutput';
+
+export interface IControllerUsernameGeneratorFuncGenerate {
+	(): IControllerUsernameGeneratorFuncGenerateOutput;
+}

--- a/src/interfaces/controllers/IControllerUsernameGeneratorFuncGenerateOutput.ts
+++ b/src/interfaces/controllers/IControllerUsernameGeneratorFuncGenerateOutput.ts
@@ -1,0 +1,3 @@
+import { IModelUsername } from '@app/interfaces/models';
+
+export type IControllerUsernameGeneratorFuncGenerateOutput = IModelUsername[];

--- a/src/interfaces/controllers/IControllerUsernameGeneratorFuncGenerateUsernameModels.ts
+++ b/src/interfaces/controllers/IControllerUsernameGeneratorFuncGenerateUsernameModels.ts
@@ -1,0 +1,6 @@
+import { IControllerUsernameGeneratorFuncGenerateUsernameModelsInput } from './IControllerUsernameGeneratorFuncGenerateUsernameModelsInput';
+import { IModelUsername } from '@app/interfaces/models';
+
+export interface IControllerUsernameGeneratorFuncGenerateUsernameModels {
+	(args: IControllerUsernameGeneratorFuncGenerateUsernameModelsInput): IModelUsername[];
+}

--- a/src/interfaces/controllers/IControllerUsernameGeneratorFuncGenerateUsernameModelsInput.ts
+++ b/src/interfaces/controllers/IControllerUsernameGeneratorFuncGenerateUsernameModelsInput.ts
@@ -1,0 +1,5 @@
+import { IModelFullName } from '@app/interfaces/models';
+
+export interface IControllerUsernameGeneratorFuncGenerateUsernameModelsInput {
+	fullNameModel: IModelFullName;
+}

--- a/src/interfaces/controllers/index.ts
+++ b/src/interfaces/controllers/index.ts
@@ -1,0 +1,7 @@
+export { IControllerUsernameGenerator } from './IControllerUsernameGenerator';
+export { IControllerUsernameGeneratorConstructor } from './IControllerUsernameGeneratorConstructor';
+export { IControllerUsernameGeneratorConstructorInput } from './IControllerUsernameGeneratorConstructorInput';
+export { IControllerUsernameGeneratorFuncGenerate } from './IControllerUsernameGeneratorFuncGenerate';
+export { IControllerUsernameGeneratorFuncGenerateOutput } from './IControllerUsernameGeneratorFuncGenerateOutput';
+export { IControllerUsernameGeneratorFuncGenerateUsernameModels } from './IControllerUsernameGeneratorFuncGenerateUsernameModels';
+export { IControllerUsernameGeneratorFuncGenerateUsernameModelsInput } from './IControllerUsernameGeneratorFuncGenerateUsernameModelsInput';

--- a/src/interfaces/models/IModelUsername.ts
+++ b/src/interfaces/models/IModelUsername.ts
@@ -1,0 +1,9 @@
+import { IModelUsernameFuncGetForename } from './IModelUsernameFuncGetForename';
+import { IModelUsernameFuncGetSurname } from './IModelUsernameFuncGetSurname';
+import { IModelUsernameFuncGetUsername } from './IModelUsernameFuncGetUsername';
+
+export interface IModelUsername {
+	getForename: IModelUsernameFuncGetForename;
+	getSurname: IModelUsernameFuncGetSurname;
+	getUsername: IModelUsernameFuncGetUsername;
+}

--- a/src/interfaces/models/IModelUsernameConstructor.ts
+++ b/src/interfaces/models/IModelUsernameConstructor.ts
@@ -1,0 +1,6 @@
+import { IModelUsername } from './IModelUsername';
+import { IModelUsernameConstructorInput } from './IModelUsernameConstructorInput';
+
+export interface IModelUsernameConstructor {
+	(args: IModelUsernameConstructorInput): IModelUsername;
+}

--- a/src/interfaces/models/IModelUsernameConstructorInput.ts
+++ b/src/interfaces/models/IModelUsernameConstructorInput.ts
@@ -1,0 +1,5 @@
+import { IModelFullName } from './IModelFullName';
+
+export interface IModelUsernameConstructorInput {
+	fullNameModel: IModelFullName;
+}

--- a/src/interfaces/models/IModelUsernameFuncGetForename.ts
+++ b/src/interfaces/models/IModelUsernameFuncGetForename.ts
@@ -1,0 +1,5 @@
+import { ICommonNameStr } from '@app/interfaces/common';
+
+export interface IModelUsernameFuncGetForename {
+	(): ICommonNameStr;
+}

--- a/src/interfaces/models/IModelUsernameFuncGetSurname.ts
+++ b/src/interfaces/models/IModelUsernameFuncGetSurname.ts
@@ -1,0 +1,5 @@
+import { ICommonNameStr } from '@app/interfaces/common';
+
+export interface IModelUsernameFuncGetSurname {
+	(): ICommonNameStr;
+}

--- a/src/interfaces/models/IModelUsernameFuncGetUsername.ts
+++ b/src/interfaces/models/IModelUsernameFuncGetUsername.ts
@@ -1,0 +1,5 @@
+import { ICommonNameStr } from '@app/interfaces/common';
+
+export interface IModelUsernameFuncGetUsername {
+	(): ICommonNameStr;
+}

--- a/src/interfaces/models/index.ts
+++ b/src/interfaces/models/index.ts
@@ -9,3 +9,9 @@ export { IModelFullNamesConstructorInput } from './IModelFullNamesConstructorInp
 export { IModelFullNamesFuncNext } from './IModelFullNamesFuncNext';
 export { IModelFullNamesFuncNextOutput } from './IModelFullNamesFuncNextOutput';
 export { IModelFullNamesPropLength } from './IModelFullNamesPropLength';
+export { IModelUsername } from './IModelUsername';
+export { IModelUsernameConstructor } from './IModelUsernameConstructor';
+export { IModelUsernameConstructorInput } from './IModelUsernameConstructorInput';
+export { IModelUsernameFuncGetForename } from './IModelUsernameFuncGetForename';
+export { IModelUsernameFuncGetSurname } from './IModelUsernameFuncGetSurname';
+export { IModelUsernameFuncGetUsername } from './IModelUsernameFuncGetUsername';

--- a/src/models/UsernameModel.ts
+++ b/src/models/UsernameModel.ts
@@ -1,0 +1,24 @@
+import { ICommonNameStr } from '@app/interfaces/common';
+import {
+	IModelUsername,
+	IModelUsernameConstructor,
+	IModelUsernameConstructorInput,
+	IModelUsernameFuncGetForename,
+	IModelUsernameFuncGetSurname,
+	IModelUsernameFuncGetUsername,
+} from '@app/interfaces/models';
+
+export const UsernameModel: IModelUsernameConstructor = ({
+	fullNameModel,
+}: IModelUsernameConstructorInput): IModelUsername => {
+	const getForename: IModelUsernameFuncGetForename = (): ICommonNameStr =>
+		fullNameModel.getForename();
+	const getSurname: IModelUsernameFuncGetSurname = (): ICommonNameStr => fullNameModel.getSurname();
+	const getUsername: IModelUsernameFuncGetUsername = (): ICommonNameStr => 'TO_BE_COMPLETED';
+
+	return {
+		getForename,
+		getSurname,
+		getUsername,
+	};
+};

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,2 +1,3 @@
 export { FullNameModel } from './FullNameModel';
 export { FullNamesModel } from './FullNamesModel';
+export { UsernameModel } from './UsernameModel';

--- a/test/unit/controllers/usernameGeneratorController.constructor.negative.test.ts
+++ b/test/unit/controllers/usernameGeneratorController.constructor.negative.test.ts
@@ -1,0 +1,134 @@
+import { FileServiceDelimiterEnum, FullNameDelimiterEnum } from '@app/config/enums';
+import { CONSTS_PATHS_TEST_DIR } from '@app/config/consts/paths';
+import { UsernameGeneratorController } from '@app/controllers';
+import { ICommonPathStr } from '@app/interfaces/common';
+import { resolve } from 'node:path';
+
+describe('UsernameGeneratorController', (): void => {
+	describe('constructor', (): void => {
+		describe('should throw the expected error', (): void => {
+			test("when 'filePathStr' is undefined", (): void => {
+				/*
+				 * Arrange: expected
+				 */
+				const errorExpected = "Invalid 'filePathStr'";
+
+				/*
+				 * Arrange: common
+				 */
+				const filePathStr: ICommonPathStr = undefined;
+				const fileServiceDelimiterEnum: FileServiceDelimiterEnum =
+					FileServiceDelimiterEnum.NEW_LINE;
+				const fullNameDelimiterEnum: FullNameDelimiterEnum = FullNameDelimiterEnum.COMMA;
+
+				/*
+				 * Act
+				 */
+				const handler = (): void => {
+					UsernameGeneratorController({
+						filePathStr,
+						fileServiceDelimiterEnum,
+						fullNameDelimiterEnum,
+					});
+				};
+
+				/*
+				 * Assert
+				 */
+				expect(handler).toThrow(errorExpected);
+			});
+			test("when 'filePathStr' is an empty string", (): void => {
+				/*
+				 * Arrange: expected
+				 */
+				const errorExpected = "Invalid 'filePathStr'";
+
+				/*
+				 * Arrange: common
+				 */
+				const filePathStr: ICommonPathStr = '';
+				const fileServiceDelimiterEnum: FileServiceDelimiterEnum =
+					FileServiceDelimiterEnum.NEW_LINE;
+				const fullNameDelimiterEnum: FullNameDelimiterEnum = FullNameDelimiterEnum.COMMA;
+
+				/*
+				 * Act
+				 */
+				const handler = (): void => {
+					UsernameGeneratorController({
+						filePathStr,
+						fileServiceDelimiterEnum,
+						fullNameDelimiterEnum,
+					});
+				};
+
+				/*
+				 * Assert
+				 */
+				expect(handler).toThrow(errorExpected);
+			});
+			test("when 'filePathStr' does not identify a file", (): void => {
+				/*
+				 * Arrange: expected
+				 */
+				const errorExpected = "Invalid 'filePathStr'";
+
+				/*
+				 * Arrange: common
+				 */
+				const filePathStr: ICommonPathStr = CONSTS_PATHS_TEST_DIR;
+				const fileServiceDelimiterEnum: FileServiceDelimiterEnum =
+					FileServiceDelimiterEnum.NEW_LINE;
+				const fullNameDelimiterEnum: FullNameDelimiterEnum = FullNameDelimiterEnum.COMMA;
+
+				/*
+				 * Act
+				 */
+				const handler = (): void => {
+					UsernameGeneratorController({
+						filePathStr,
+						fileServiceDelimiterEnum,
+						fullNameDelimiterEnum,
+					});
+				};
+
+				/*
+				 * Assert
+				 */
+				expect(handler).toThrow(errorExpected);
+			});
+			test("when 'fileServiceDelimiterEnum' is null", (): void => {
+				/*
+				 * Arrange: expected
+				 */
+				const errorExpected = "Invalid 'delimiter'";
+
+				/*
+				 * Arrange: common
+				 */
+				const filePathStr: ICommonPathStr = resolve(
+					`${CONSTS_PATHS_TEST_DIR}`,
+					'./doubles/fakes/data/fullNames.txt',
+				);
+				const fileServiceDelimiterEnum: FileServiceDelimiterEnum = FileServiceDelimiterEnum.NULL;
+				const fullNameDelimiterEnum: FullNameDelimiterEnum = FullNameDelimiterEnum.COMMA;
+
+				/*
+				 * Act
+				 */
+				const handler = (): void => {
+					UsernameGeneratorController({
+						filePathStr,
+						fileServiceDelimiterEnum,
+						fullNameDelimiterEnum,
+					});
+				};
+
+				/*
+				 * Assert
+				 */
+				expect(handler).toThrow(errorExpected);
+			});
+		});
+	});
+});

--- a/test/unit/controllers/usernameGeneratorController.constructor.positive.test.ts
+++ b/test/unit/controllers/usernameGeneratorController.constructor.positive.test.ts
@@ -1,0 +1,40 @@
+import { resolve } from 'node:path';
+import { FileServiceDelimiterEnum, FullNameDelimiterEnum } from '@app/config/enums';
+import { UsernameGeneratorController } from '@app/controllers';
+import { IControllerUsernameGenerator } from '@app/interfaces/controllers';
+import { ICommonPathStr } from '@app/interfaces/common';
+import { CONSTS_PATHS_TEST_DIR } from '@app/config/consts/paths';
+
+describe('UsernameGeneratorController', (): void => {
+	describe('constructor', (): void => {
+		describe('should instantiate', (): void => {
+			test('when receiving a valid set of params', (): void => {
+				/*
+				 * Arrange
+				 */
+				const filePathStr: ICommonPathStr = resolve(
+					`${CONSTS_PATHS_TEST_DIR}`,
+					'./doubles/fakes/data/fullNames.txt',
+				);
+				const fileServiceDelimiterEnum: FileServiceDelimiterEnum =
+					FileServiceDelimiterEnum.NEW_LINE;
+				const fullNameDelimiterEnum: FullNameDelimiterEnum = FullNameDelimiterEnum.COMMA;
+
+				/*
+				 * Act
+				 */
+				const usernameGeneratorController: IControllerUsernameGenerator =
+					UsernameGeneratorController({
+						filePathStr,
+						fileServiceDelimiterEnum,
+						fullNameDelimiterEnum,
+					});
+
+				/*
+				 * Assert
+				 */
+				expect(usernameGeneratorController).toBeTruthy();
+			});
+		});
+	});
+});

--- a/test/unit/controllers/usernameGeneratorController.generate.positive.test.ts
+++ b/test/unit/controllers/usernameGeneratorController.generate.positive.test.ts
@@ -1,0 +1,49 @@
+import { resolve } from 'node:path';
+import { CONSTS_PATHS_TEST_DIR } from '@app/config/consts/paths';
+import { FileServiceDelimiterEnum, FullNameDelimiterEnum } from '@app/config/enums';
+import { UsernameGeneratorController } from '@app/controllers';
+import { IControllerUsernameGenerator } from '@app/interfaces/controllers';
+import { ICommonPathStr } from '@app/interfaces/common';
+import { IModelUsername } from '@app/interfaces/models';
+
+describe('UsernameGeneratorController', (): void => {
+	describe('generate', (): void => {
+		describe("should return the expected number of 'usernameModels'", (): void => {
+			test('when receiving a valid set of params', (): void => {
+				/*
+				 * Arrange: expected
+				 */
+				const usernameModelsLengthExpected = 3;
+
+				/*
+				 * Arrange: common
+				 */
+				const filePathStr: ICommonPathStr = resolve(
+					`${CONSTS_PATHS_TEST_DIR}`,
+					'./doubles/fakes/data/fullNames.txt',
+				);
+				const fileServiceDelimiterEnum: FileServiceDelimiterEnum =
+					FileServiceDelimiterEnum.NEW_LINE;
+
+				const fullNameDelimiterEnum: FullNameDelimiterEnum = FullNameDelimiterEnum.COMMA;
+				const usernameGeneratorController: IControllerUsernameGenerator =
+					UsernameGeneratorController({
+						filePathStr,
+						fileServiceDelimiterEnum,
+						fullNameDelimiterEnum,
+					});
+
+				/*
+				 * Act
+				 */
+				const usernameModels: IModelUsername[] = usernameGeneratorController.generate();
+				const usernameModelsLengthFound: number = usernameModels.length;
+
+				/*
+				 * Assert
+				 */
+				expect(usernameModelsLengthFound).toBe(usernameModelsLengthExpected);
+			});
+		});
+	});
+});

--- a/test/unit/models/usernameModel.constructor.test.ts
+++ b/test/unit/models/usernameModel.constructor.test.ts
@@ -1,0 +1,29 @@
+import { FullNameDelimiterEnum } from '@app/config/enums';
+import { FullNameModel, UsernameModel } from '@app/models';
+import { ICommonFullNameStr } from '@app/interfaces/common';
+import { IModelFullName, IModelUsername } from '@app/interfaces/models';
+
+describe('UsernameModel', (): void => {
+	describe('constructor', (): void => {
+		describe('should instantiate', (): void => {
+			test("when receiving a 'fullNameModel'", (): void => {
+				/*
+				 * Arrange
+				 */
+				const fullNameStr: ICommonFullNameStr = 'forename,surname';
+				const fullNameDelimiterEnum: FullNameDelimiterEnum = FullNameDelimiterEnum.COMMA;
+				const fullNameModel: IModelFullName = FullNameModel({ fullNameStr, fullNameDelimiterEnum });
+
+				/*
+				 * Act
+				 */
+				const usernameModel: IModelUsername = UsernameModel({ fullNameModel });
+
+				/*
+				 * Assert
+				 */
+				expect(usernameModel).toBeTruthy();
+			});
+		});
+	});
+});

--- a/test/unit/models/usernameModel.getForname.test.ts
+++ b/test/unit/models/usernameModel.getForname.test.ts
@@ -1,0 +1,34 @@
+import { FullNameDelimiterEnum } from '@app/config/enums';
+import { FullNameModel, UsernameModel } from '@app/models';
+import { ICommonFullNameStr, ICommonNameStr } from '@app/interfaces/common';
+import { IModelFullName, IModelUsername } from '@app/interfaces/models';
+
+describe('UsernameModel', (): void => {
+	describe('getForename', (): void => {
+		describe('should return the expected forename', (): void => {
+			test("when receiving a 'fullNameModel'", (): void => {
+				/*
+				 * Arrange: expected
+				 */
+				const forenameExpected = 'TEST_FORENAME';
+				/*
+				 * Arrange: common
+				 */
+				const fullNameStr: ICommonFullNameStr = `${forenameExpected},surname`;
+				const fullNameDelimiterEnum: FullNameDelimiterEnum = FullNameDelimiterEnum.COMMA;
+				const fullNameModel: IModelFullName = FullNameModel({ fullNameStr, fullNameDelimiterEnum });
+				const usernameModel: IModelUsername = UsernameModel({ fullNameModel });
+
+				/*
+				 * Act
+				 */
+				const forenameFound: ICommonNameStr = usernameModel.getForename();
+
+				/*
+				 * Assert
+				 */
+				expect(forenameFound).toBe(forenameExpected);
+			});
+		});
+	});
+});

--- a/test/unit/models/usernameModel.getSurame.test.ts
+++ b/test/unit/models/usernameModel.getSurame.test.ts
@@ -1,0 +1,34 @@
+import { FullNameDelimiterEnum } from '@app/config/enums';
+import { FullNameModel, UsernameModel } from '@app/models';
+import { ICommonFullNameStr, ICommonNameStr } from '@app/interfaces/common';
+import { IModelFullName, IModelUsername } from '@app/interfaces/models';
+
+describe('UsernameModel', (): void => {
+	describe('getSurname', (): void => {
+		describe('should return the expected surname', (): void => {
+			test("when receiving a 'fullNameModel'", (): void => {
+				/*
+				 * Arrange: expected
+				 */
+				const surnameExpected = 'TEST_SURNAME';
+				/*
+				 * Arrange: common
+				 */
+				const fullNameStr: ICommonFullNameStr = `forename,${surnameExpected}`;
+				const fullNameDelimiterEnum: FullNameDelimiterEnum = FullNameDelimiterEnum.COMMA;
+				const fullNameModel: IModelFullName = FullNameModel({ fullNameStr, fullNameDelimiterEnum });
+				const usernameModel: IModelUsername = UsernameModel({ fullNameModel });
+
+				/*
+				 * Act
+				 */
+				const surnameFound: ICommonNameStr = usernameModel.getSurname();
+
+				/*
+				 * Assert
+				 */
+				expect(surnameFound).toBe(surnameExpected);
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Overview

The changes within this PR encompass:
- An initial version of the UsernameGeneratorController
- An initial version of the UsernameModel
- Unit test for the above with approximately 90% coverage, across the whole codebase.

## Caveat
Once the permutations have been added, both UsernameGeneratorController and UsernameModel will be likely to require modification. Additionally, the body of the 'generateUsernameModels' function (within the new controller) will need to be completed.  